### PR TITLE
Accelerate Phrase Extraction

### DIFF
--- a/keywords_extractor/api_service.py
+++ b/keywords_extractor/api_service.py
@@ -44,14 +44,14 @@ async def main(country: str,
     if page_id is not None:
         ads = fetch_db_data.merge_page_name_with_associated_ads(ads, page_name)
 
-    ads_summary = fetch_db_data.create_ads_summary_table(ads, country, max_table_length)
+    ads_summary = fetch_db_data.create_ads_summary_table(ads, country)
 
     # if ads is an empty list, raise an exception
     if len(ads) == 0:
         raise HTTPException(status_code=404, detail="No ads found for the given params")
 
     if is_wordcloud:
-        top_keywords = process_ads.extract_keywords([ad["creative_bodies"] for ad in ads],
+        top_keywords = process_ads.extract_keywords(ads,
                                                     top_n=top_n_keywords,
                                                     similarity_threshold=keyword_share_word_threshold,
                                                     is_politically_relevant_threshold=is_politically_relevant_threshold,
@@ -64,7 +64,7 @@ async def main(country: str,
         top_keywords = fetch_db_data.top_keyword_to_d3_dict_list(top_keywords)
 
         # make a result dict with the image base64 string and the top keywords
-        result_dict = {"img": img_base64, "result": top_keywords, "summary_table": ads_summary}
+        result_dict = {"img": img_base64, "result": top_keywords}
         return json.dumps(result_dict)
 
     else:
@@ -78,7 +78,7 @@ async def main(country: str,
         top_key_phrases = fetch_db_data.top_keyphrase_to_d3_dict_list(top_key_phrases)
 
         # make a result dict with the image base64 string and the top key phrases
-        result_dict = {"img": img_base64, "result": top_key_phrases, "summary_table": ads_summary}
+        result_dict = {"img": img_base64, "result": top_key_phrases}
         return json.dumps(result_dict)
 
 

--- a/keywords_extractor/api_service.py
+++ b/keywords_extractor/api_service.py
@@ -25,7 +25,9 @@ async def main(country: str,
                is_politically_relevant_threshold: float = 0.75,
                if_extended_stop_words: bool = False,
                if_generate_img_base64: bool = True,
-               dpi: int = 100):
+               dpi: int = 100,
+               num_processes: int = 32,
+               minimum_number_of_unique_ads_to_parallel: int = 30):
     # if both funding_entity and page_id are not None, raise an exception
     if funding_entity is not None and page_id is not None:
         raise HTTPException(status_code=400, detail="Both funding_entity and page_id cannot be specified")
@@ -68,7 +70,9 @@ async def main(country: str,
         ads_unique_creatives_only = fetch_db_data.create_ads_unique_creatives_only_table(ads, country)
         top_key_phrases = process_ads.extract_top_key_phrase(ads_unique_creatives_only,
                                                              top_n=top_n_key_phrases,
-                                                             share_word_threshold=key_phrase_share_word_threshold)
+                                                             share_word_threshold=key_phrase_share_word_threshold,
+                                                             num_processes=num_processes,
+                                                             minimum_number_of_unique_ads_to_parallel=minimum_number_of_unique_ads_to_parallel,)
         img_base64 = None
         if if_generate_img_base64:
             img_base64 = generate_wordcloud.generate_phrase_wordcloud(top_key_phrases, dpi=dpi, debug=False)

--- a/keywords_extractor/api_service.py
+++ b/keywords_extractor/api_service.py
@@ -25,7 +25,6 @@ async def main(country: str,
                is_politically_relevant_threshold: float = 0.75,
                if_extended_stop_words: bool = False,
                if_generate_img_base64: bool = True,
-               max_table_length: int = 100,
                dpi: int = 100):
     # if both funding_entity and page_id are not None, raise an exception
     if funding_entity is not None and page_id is not None:
@@ -43,8 +42,6 @@ async def main(country: str,
     ads = fetch_db_data.fetch_ads(db, country, funding_entity, page_id, start_time, end_time)
     if page_id is not None:
         ads = fetch_db_data.merge_page_name_with_associated_ads(ads, page_name)
-
-    ads_summary = fetch_db_data.create_ads_summary_table(ads, country)
 
     # if ads is an empty list, raise an exception
     if len(ads) == 0:
@@ -68,7 +65,8 @@ async def main(country: str,
         return json.dumps(result_dict)
 
     else:
-        top_key_phrases = process_ads.extract_top_key_phrase(ads,
+        ads_unique_creatives_only = fetch_db_data.create_ads_unique_creatives_only_table(ads, country)
+        top_key_phrases = process_ads.extract_top_key_phrase(ads_unique_creatives_only,
                                                              top_n=top_n_key_phrases,
                                                              share_word_threshold=key_phrase_share_word_threshold)
         img_base64 = None

--- a/keywords_extractor/fetch_db_data.py
+++ b/keywords_extractor/fetch_db_data.py
@@ -55,7 +55,7 @@ def merge_multiple_creative_bodies(ads):
     return ads
 
 
-def create_ads_summary_table(ads, country, max_table_length=100):
+def create_ads_summary_table(ads, country):
     # create a list of dictionaries of unique creative_bodies
     ads_summary_table = []
     for ad in ads:
@@ -83,8 +83,6 @@ def create_ads_summary_table(ads, country, max_table_length=100):
     # sort the ads_summary_table by frequency
     ads_summary_table = sorted(ads_summary_table, key=lambda x: x["freq"], reverse=True)
     # if the length of the ads_summary_table is greater than max_table_length, then only keep the top max_table_length
-    if len(ads_summary_table) > max_table_length:
-        ads_summary_table = ads_summary_table[:max_table_length]
 
     return ads_summary_table
 

--- a/keywords_extractor/fetch_db_data.py
+++ b/keywords_extractor/fetch_db_data.py
@@ -2,6 +2,7 @@ from pymongo import MongoClient
 import pandas as pd
 import process_ads
 import urllib.parse
+import time
 
 
 def return_client_and_db(mongo_uri='mongodb://localhost:27017'):
@@ -43,19 +44,18 @@ def merge_page_name_with_associated_ads(ads, page_name):
 
 def merge_multiple_creative_bodies(ads):
     # convert creative_bodies to str
-
     for ad in ads:
         creative_bodies_combined = ""
-        try:
-            for creative_body in ad["creative_bodies"]:
-                creative_bodies_combined += " " + creative_body
-            ad["creative_bodies"] = creative_bodies_combined
-        except:
-            ad["creative_bodies"] = ""
+
+        if isinstance(ad.get("creative_bodies"), (list, tuple)):
+            creative_bodies_combined = " ".join(ad["creative_bodies"])
+
+        ad["creative_bodies"] = creative_bodies_combined
+
     return ads
 
 
-def create_ads_summary_table(ads, country):
+def create_ads_unique_creatives_only_table(ads, country, add_summary_info_instead_of_ad_obj=False):
     # create a list of dictionaries of unique creative_bodies
     ads_summary_table = []
     for ad in ads:
@@ -69,16 +69,30 @@ def create_ads_summary_table(ads, country):
                 break
         # if the ad is not found in the ads_summary_table, add it to the ads_summary_table
         if not found_previous_ad:
-            # URL-encode the creative_body string
-            creative_body_encoded = urllib.parse.quote(ad["creative_bodies"])
-            # construct the snapshot_url based on the country and creative_body_encoded
-            country = country.upper()
-            snapshot_url = f"https://www.facebook.com/ads/library/?active_status=all&ad_type=political_and_issue_ads&country={country}&q={creative_body_encoded}&media_type=all"
-            ads_summary_table.append({"creative_bodies": ad["creative_bodies"],
-                                      "freq": 1,
-                                      "ad_ids": [ad["_id"]],
-                                      "funding_entity": ad["funding_entity"],
-                                      "snapshot_url": snapshot_url})
+            if add_summary_info_instead_of_ad_obj:
+                # URL-encode the creative_body string
+                creative_body_encoded = urllib.parse.quote(ad["creative_bodies"])
+                # construct the snapshot_url based on the country and creative_body_encoded
+                country = country.upper()
+                snapshot_url = (f"https://www.facebook.com/ads/library/?active_status=all&ad_type"
+                                f"=political_and_issue_ads&country={country}&q={creative_body_encoded}&media_type=all")
+                ads_summary_table.append({"creative_bodies": ad["creative_bodies"],
+                                          "freq": 1,
+                                          "ad_ids": [ad["_id"]],
+                                          "funding_entity": ad["funding_entity"],
+                                          "snapshot_url": snapshot_url})
+            else:
+                new_ad = {}
+                for key in ad:
+                    # if current key is _id, then change it to ad_ids
+                    if key == "_id":
+                        new_ad["ad_ids"] = [ad[key]]
+                        continue
+                    new_ad[key] = ad[key]
+                new_ad["freq"] = 1
+                # add the new ad to the ads_summary_table
+                ads_summary_table.append(new_ad)
+
 
     # sort the ads_summary_table by frequency
     ads_summary_table = sorted(ads_summary_table, key=lambda x: x["freq"], reverse=True)
@@ -137,17 +151,11 @@ if __name__ == '__main__':
     if page_id is not None:
         ads = merge_page_name_with_associated_ads(ads, page_name)
 
-    ads_summary = create_ads_summary_table(ads, country, max_table_length=100)
-    # # convert it to markdown
-    # ads_summary = pd.DataFrame(ads_summary)
-    # # display as markdown
-    # print(ads_summary.to_markdown())
-
     # if ads is an empty list, raise an exception
     if len(ads) == 0:
         raise "No ads found for the given params"
 
-    is_wordcloud = True
+    is_wordcloud = False
     top_n_keywords = 100
     keyword_share_word_threshold = 0.49
     is_politically_relevant_threshold = 0.75
@@ -158,27 +166,23 @@ if __name__ == '__main__':
     if len(ads) == 0:
         raise "No ads found for the given params"
 
+    start_time = time.time()
     if is_wordcloud:
-        # time it
-        import time
-
-        start_time = time.time()
         top_keywords = process_ads.extract_keywords([ad["creative_bodies"] for ad in ads],
                                                     top_n=top_n_keywords,
                                                     similarity_threshold=keyword_share_word_threshold,
                                                     is_politically_relevant_threshold=is_politically_relevant_threshold,
                                                     if_only_politically_relevant=False,
                                                     if_extended_stop_words=False)
-        print(top_keyword_to_d3_dict_list(top_keywords))
-        # img_base64 = generate_wordcloud.generate_keyword_wordcloud(top_keywords, debug=True)
 
     else:
-        top_key_phrases = process_ads.extract_top_key_phrase(ads,
+        ads_unique_creatives_only = create_ads_unique_creatives_only_table(ads, country)
+        top_key_phrases = process_ads.extract_top_key_phrase(ads_unique_creatives_only,
                                                              top_n=top_n_key_phrases,
                                                              share_word_threshold=key_phrase_share_word_threshold,
-                                                             min_length=2,
-                                                             max_length=4)
-        print(top_keyphrase_to_d3_dict_list(top_key_phrases))
-        # img_base64 = generate_wordcloud.generate_phrase_wordcloud(top_key_phrases, debug=True)
+                                                             debug=True)
+
+    end_time = time.time()
+    print(f"Time elapsed: {end_time - start_time} seconds")
 
     close_connection(client)

--- a/keywords_extractor/process_ads.py
+++ b/keywords_extractor/process_ads.py
@@ -142,7 +142,7 @@ def get_page_names_plus_ads_dict_list(combined_ads):
     return page_names_plus_ads_dict_list
 
 
-def extract_keywords(texts, top_n=200, is_politically_relevant_threshold=0.75, similarity_threshold=0.5,
+def extract_keywords(ads, top_n=200, is_politically_relevant_threshold=0.75, similarity_threshold=0.5,
                      if_only_politically_relevant=False, if_extended_stop_words=False):
     if if_extended_stop_words:
         extended_stop_words = extend_stop_words(stop_words)
@@ -151,6 +151,8 @@ def extract_keywords(texts, top_n=200, is_politically_relevant_threshold=0.75, s
     else:
         # Use Tfidf Vectorizer to get important words based on TF-IDF scores
         vectorizer = TfidfVectorizer(stop_words=list(stop_words), max_features=200)
+
+    texts = [ad["creative_bodies"] for ad in ads]
 
     tfidf_matrix = vectorizer.fit_transform(texts)
     feature_names = vectorizer.get_feature_names_out()

--- a/keywords_extractor/process_ads.py
+++ b/keywords_extractor/process_ads.py
@@ -89,7 +89,7 @@ def parallel_extract_phrases(chunk_data, min_length=1, max_length=3, debug=False
 
 
 def extract_top_key_phrase(unique_creative_ads_table, top_n=200, share_word_threshold=0.49, min_length=1, max_length=3,
-                           num_processes=4, minimum_number_of_unique_ads_to_parallel=32, debug=False):
+                           num_processes=32, minimum_number_of_unique_ads_to_parallel=30, debug=False):
     key_phrase_freq = defaultdict(int)
 
     if len(unique_creative_ads_table) > minimum_number_of_unique_ads_to_parallel:


### PR DESCRIPTION
New method:
1.	group ads by unique creatives first
2.	Only extract the phrase of those unique creatives since ads with the same creatives will results in same phrases being extracted.
3.	artificially populate the combine phrase list by repeating the phrases from a unique creatives with the number of times the same creatives is used in ads
4.	merge the same phrase to create the freq list (existing code)

Besides that, the phrase extractor now will parallel automatically when the number of unique ads > 30. To set the threshold, as well as how many process to use, use 'num_processes' and 'minimum_number_of_unique_ads_to_parallel' of the api